### PR TITLE
curbside parameter: API and passing to Graph Hopper engine

### DIFF
--- a/ors-api/src/main/java/org/heigit/ors/api/requests/routing/RouteRequest.java
+++ b/ors-api/src/main/java/org/heigit/ors/api/requests/routing/RouteRequest.java
@@ -137,6 +137,12 @@ public class RouteRequest extends APIRequest implements RouteRequestParameterNam
     @JsonIgnore
     private boolean hasMaximumSearchRadii = false;
 
+    @Schema(name = PARAM_CURBSIDE,
+            description = "Forces the route to stick to right/left side of the road",
+            defaultValue = "")
+    @JsonProperty(value = PARAM_CURBSIDE)
+    private String curbside;
+
     @Schema(name = PARAM_BEARINGS, description = """
             Specifies a list of pairs (bearings and deviations) to filter the segments of the road network a waypoint can snap to.
             "For example `bearings=[[45,10],[120,20]]`.
@@ -370,6 +376,10 @@ public class RouteRequest extends APIRequest implements RouteRequestParameterNam
 
     public List<List<Double>> getCoordinates() {
         return coordinates;
+    }
+
+    public String getCurbside() {
+        return curbside;
     }
 
     public void setCoordinates(List<List<Double>> coordinates) {

--- a/ors-api/src/main/java/org/heigit/ors/api/services/RoutingService.java
+++ b/ors-api/src/main/java/org/heigit/ors/api/services/RoutingService.java
@@ -204,6 +204,7 @@ public class RoutingService extends ApiService {
 
         routingRequest.setSearchParameters(params);
 
+        routingRequest.setCurbside(request.getCurbside());
         return routingRequest;
     }
 

--- a/ors-engine/src/main/java/org/heigit/ors/routing/RouteRequestParameterNames.java
+++ b/ors-engine/src/main/java/org/heigit/ors/routing/RouteRequestParameterNames.java
@@ -39,4 +39,5 @@ public interface RouteRequestParameterNames {
     String PARAM_SCHEDULE_ROWS = "schedule_rows";
     String PARAM_WALKING_TIME = "walking_time";
     String PARAM_IGNORE_TRANSFERS = "ignore_transfers";
+    String PARAM_CURBSIDE = "curbside";
 }

--- a/ors-engine/src/main/java/org/heigit/ors/routing/RoutingProfileManager.java
+++ b/ors-engine/src/main/java/org/heigit/ors/routing/RoutingProfileManager.java
@@ -298,7 +298,7 @@ public class RoutingProfileManager {
                 }
             }
 
-            GHResponse gr = rp.computeRoute(c0.y, c0.x, c1.y, c1.x, bearings, radiuses, skipSegments.contains(i), searchParams, req.getGeometrySimplify());
+            GHResponse gr = rp.computeRoute(c0.y, c0.x, c1.y, c1.x, bearings, radiuses, skipSegments.contains(i), searchParams, req.getGeometrySimplify(), req.getCurbside());
 
             if (gr.hasErrors()) {
                 if (!gr.getErrors().isEmpty()) {

--- a/ors-engine/src/main/java/org/heigit/ors/routing/RoutingRequest.java
+++ b/ors-engine/src/main/java/org/heigit/ors/routing/RoutingRequest.java
@@ -44,6 +44,7 @@ public class RoutingRequest extends ServiceRequest {
     private List<Integer> skipSegments = new ArrayList<>();
     private boolean includeCountryInfo = false;
     private double maximumSpeed;
+    private String curbside;
 
     private String responseFormat = "json";
     // Fields specific to GraphHopper GTFS
@@ -240,6 +241,13 @@ public class RoutingRequest extends ServiceRequest {
 
     public boolean isRoundTripRequest() {
         return this.coordinates.length == 1 && this.searchParameters.getRoundTripLength() > 0;
+    }
+
+    public String getCurbside() {
+        return  curbside;
+    }
+    public void setCurbside(String value){
+        curbside = value;
     }
 
     public void setSchedule(boolean schedule) {


### PR DESCRIPTION
1. Adding curbside parameter ("right" or "left" values) to the directions API (omitting the parameter produces a normal behaviour)
2. Passing curbside to Graph Hopper engine
3. Changing some GH options (contracted hierarchy speedups disabled) when this parameter is set.